### PR TITLE
Fix file handle leak in load_rgba_image

### DIFF
--- a/src/avatar_creator/core.py
+++ b/src/avatar_creator/core.py
@@ -43,14 +43,18 @@ def recolor_to_rgb(
 
 
 def load_rgba_image(file_path: str) -> Image.Image:
-    """
-    Load an image from the given file_path and convert it to RGBA mode.
+    """Load an image from ``file_path`` and return it in RGBA mode.
+
+    The previous implementation opened the file directly and returned the
+    converted image. This left the file handle open which could lead to
+    resource warnings on some platforms. Opening the file using a context
+    manager ensures the file handle is closed immediately after loading.
 
     Args:
         file_path (str): The path to the image file to load.
 
     Returns:
-        Image.Image: The loaded image in RGBA mode.
+        Image.Image: The loaded image converted to RGBA mode.
 
     Example:
         ```python
@@ -58,7 +62,8 @@ def load_rgba_image(file_path: str) -> Image.Image:
         img.show()
         ```
     """
-    return Image.open(file_path).convert("RGBA")
+    with Image.open(file_path) as img:
+        return img.convert("RGBA")
 
 def merge_images(
     base_img: Image.Image,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure the package under 'src' is importable without installation
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -36,6 +36,15 @@ def test_load_rgba_image_loads_and_converts(tmp_path):
     assert loaded.size == img.size
     assert list(loaded.getdata())[0] == (10, 20, 30, 40)
 
+def test_load_rgba_image_closes_file(tmp_path):
+    img = create_test_image((1, 2, 3, 4))
+    file_path = tmp_path / "tmp.png"
+    img.save(file_path)
+    _ = load_rgba_image(file_path)
+    # Deleting the file should not raise an exception if the handle is closed
+    file_path.unlink()
+    assert not file_path.exists()
+
 def test_merge_images_merges_two_images():
     base = create_test_image((255, 0, 0, 255))
     overlay = create_test_image((0, 255, 0, 128))


### PR DESCRIPTION
## Summary
- fix load_rgba_image to close files after reading
- add regression test covering the closed handle
- ensure tests discover src package without installation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841bdaa4438833298f8b8e562161383